### PR TITLE
Bignumbers As Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Javascript uses floating numbers to store all numbers. That means that past a ce
 
 global-json-override module provides a simple override of the following global JSON object methods, to handle the described above:
 * `parse`
-* `stringify`
 
 ### Usage
 

--- a/index.js
+++ b/index.js
@@ -21,5 +21,4 @@ module.exports = override();
  */
 function override () {
     JSON.parse = JSONbigInt.parse;
-    JSON.stringify = JSONbigInt.stringify;
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,14 @@ This is due to the fact the Javascript uses floating numbers to
 store all numbers. Therefore, past a certain point (Number.MAX_SAFE_INTEGER),
 integers will be incorrect due to the floating point percision.
  */
-var JSONbigInt = require( 'json-bigint' );
+
+// We want to convert all BigInts to be-and-stay strings, so it would not
+// 'parse' big numbers values to objects representation
+var STORE_AS_STRING = true;
+
+var JSONbigInt = require( 'json-bigint' )({
+    storeAsString: STORE_AS_STRING
+});
 
 module.exports = override();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-json-override",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Overwrites the global JSON.parse with json-bigint",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 var MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER;
 
 describe( 'Global JSON Override', function () {
-    it( 'throws an error for unparsable strings', function ( done ) {
+    it( 'throws an error for unparsable strings', function () {
         var parsed;
         var badJsonString = '{"name":"somename}';
 
@@ -27,14 +27,11 @@ describe( 'Global JSON Override', function () {
         }
 
         if ( parsed ) {
-            var err = new Error( 'Parsing should have failed.' );
-            done ( err );
-        } else {
-            done();
+            throw new Error( 'Parsing should have failed.' );
         }
     })
 
-    it( 'does not lose precision for parsing unsafe integers', function ( done ) {
+    it( 'does not lose precision for parsing unsafe integers', function () {
         var max = new BigNumber( MAX_SAFE_INTEGER );
         var min = new BigNumber( MIN_SAFE_INTEGER );
 
@@ -75,14 +72,11 @@ describe( 'Global JSON Override', function () {
         }
 
         if ( i !== values.length ) {
-            var err = new Error( 'Not all values were tested.' )
-            done( err );
-        } else {
-            done();
+            throw new Error( 'Not all values were tested.' )
         }
     })
 
-    it( 'parses safe integers to numbers', function ( done ) {
+    it( 'parses safe integers to numbers', function () {
         var values = [
             MAX_SAFE_INTEGER,
             MIN_SAFE_INTEGER
@@ -106,7 +100,5 @@ describe( 'Global JSON Override', function () {
         testedValues.forEach( function ( val ) {
             assert( typeof val === 'number' );
         })
-
-        done();
     })
 });

--- a/test.js
+++ b/test.js
@@ -48,4 +48,27 @@ describe( 'Global JSON Override', function () {
 
         done();
     })
+
+    it( 'does not parse big numbers to objects', function ( done ) {
+        var values = [ MAX_SAFE_INTEGER, MIN_SAFE_INTEGER ];
+
+        // Construct an array of values to test. Each value is parsed
+        var testedValues = [].map.call( values, function ( val ) {
+            val = val.toString();
+            return JSON.parse( val );
+        })
+
+        // expected type
+        var expected = 'string';
+        testedValues.forEach( function ( val ) {
+
+            // When 'storeAsString' configured as true, it sohuld parse
+            // the big integers to strings and not to object representation
+            // of big numbers.
+            var type = typeof val;
+            assert.equal( type, expected );
+        })
+
+        done();
+    })
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,12 @@
 var assert = require( 'assert' );
 var parseBig = require( './index' );
 
+// json-bigint uses bignumber.js to check whether the number is
+// bigger than 15 digits to determine if it should be set as a
+// string (or 'BigNumber', in case `storeAsString` is configured false
+// to parse big integers as BigNumber objects).
 var MAX_NUMBER_LENGTH = 15;
+
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 var MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER;
 
@@ -79,12 +84,10 @@ describe( 'Global JSON Override', function () {
         // Construct an array of values to test. Each value is parsed
         var testedValues = [].map.call( values, function ( val ) {
             val = val.toString();
-            // json-bigint uses bignumber.js to check whether the number is
-            // bigger than 15 digits (MAX_NUMBER_LENGTH) to determine if it
-            // should be set as a string (or 'BigNumber', in case `storeAsString`
-            // is configured false to parse big integers as BigNumber objects).
-            // For the purposes of this test - we want to make sure are tested
-            // values are indeed less than 15 digits
+
+            // We want to make sure that the tested values are indeed
+            // less than 15 digits (MAX_NUMBER_LENGTH) so we can test
+            // if they are parsed as numbers
             if ( val.length > MAX_NUMBER_LENGTH ) {
                 val = val.slice( 0, MAX_NUMBER_LENGTH );
             }

--- a/test.js
+++ b/test.js
@@ -36,7 +36,6 @@ describe( 'Global JSON Override', function () {
         })
 
         testedValues.forEach( function ( val ) {
-            val = new String( val );
             var lastDigit = val[ val.length - 1 ];
 
             // we want to test that while the module is

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var assert = require( 'assert' );
 var parseBig = require( './index' );
 
+var MAX_NUMBER_LENGTH = 15;
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 var MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER;
 
@@ -65,6 +66,35 @@ describe( 'Global JSON Override', function () {
             // When 'storeAsString' configured as true, it sohuld parse
             // the big integers to strings and not to object representation
             // of big numbers.
+            var type = typeof val;
+            assert.equal( type, expected );
+        })
+
+        done();
+    })
+
+    it( 'parses small integers to numbers', function ( done ) {
+        var values = [ MAX_SAFE_INTEGER, MIN_SAFE_INTEGER ]
+
+        // Construct an array of values to test. Each value is parsed
+        var testedValues = [].map.call( values, function ( val ) {
+            val = val.toString();
+            // json-bigint uses bignumber.js to check whether the number is
+            // bigger than 15 digits (MAX_NUMBER_LENGTH) to determine if it
+            // should be set as a string (or 'BigNumber', in case `storeAsString`
+            // is configured false to parse big integers as BigNumber objects).
+            // For the purposes of this test - we want to make sure are tested
+            // values are indeed less than 15 digits
+            if ( val.length > MAX_NUMBER_LENGTH ) {
+                val = val.slice( 0, MAX_NUMBER_LENGTH );
+            }
+
+            return JSON.parse( val );
+        })
+
+        // expected type
+        var expected = 'number';
+        testedValues.forEach( function ( val ) {
             var type = typeof val;
             assert.equal( type, expected );
         })


### PR DESCRIPTION
- Set the `storeAsString` option to `true` to store big numbers as strings, and not as big numbers object representation (`json-bigint` uses `bignumber.js` when representing big integers as objects).
- Removed the override for `JSON.stringify`
